### PR TITLE
Adding AUTH support, more error handling, and timeouts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/RedisLabs/sentinel_tunnel

--- a/sentinel_tunnel_configuration_example.json
+++ b/sentinel_tunnel_configuration_example.json
@@ -3,6 +3,9 @@
 		"node1.local:8001",
 		"node2.local:8001"
 	],
+	"Sentinel_dial_timeout": 1000,
+	"Sentinel_command_timeout": 1000,
+	"Sentinel_proxy_timeout": 1000,
 	"Databases":[
 		{
 			"Name":"db1",

--- a/st_sentinel_connection/st_sentinel_connection.go
+++ b/st_sentinel_connection/st_sentinel_connection.go
@@ -18,6 +18,8 @@ type Get_master_addr_reply struct {
 
 type Sentinel_connection struct {
 	sentinels_addresses              []string
+	sentinel_dial_timeout            time.Duration
+	sentinel_command_timeout         time.Duration
 	current_sentinel_connection      net.Conn
 	reader                           *bufio.Reader
 	writer                           *bufio.Writer
@@ -34,7 +36,7 @@ func (c *Sentinel_connection) parseResponse() (request []string, err error, is_c
 	var ret []string
 	buf, _, e := c.reader.ReadLine()
 	if e != nil {
-		return nil, errors.New("failed read line from client"), client_closed
+		return nil, fmt.Errorf("failed read line from client: %v", e), client_closed
 	}
 	if len(buf) == 0 {
 		return nil, errors.New("failed read line from client"), client_closed
@@ -50,7 +52,7 @@ func (c *Sentinel_connection) parseResponse() (request []string, err error, is_c
 	for i := 0; i < mbulk_size; i++ {
 		buf1, _, e1 := c.reader.ReadLine()
 		if e1 != nil {
-			return nil, errors.New("failed read line from client"), client_closed
+			return nil, fmt.Errorf("failed read line from client: %v", e1), client_closed
 		}
 		if len(buf1) == 0 {
 			return nil, errors.New("failed read line from client"), client_closed
@@ -61,7 +63,7 @@ func (c *Sentinel_connection) parseResponse() (request []string, err error, is_c
 		bulk_size, _ := strconv.Atoi(string(buf1[1:]))
 		buf2, _, e2 := c.reader.ReadLine()
 		if e2 != nil {
-			return nil, errors.New("failed read line from client"), client_closed
+			return nil, fmt.Errorf("failed read line from client: %v", e2), client_closed
 		}
 		bulk := string(buf2)
 		if len(bulk) != bulk_size {
@@ -73,15 +75,22 @@ func (c *Sentinel_connection) parseResponse() (request []string, err error, is_c
 }
 
 func (c *Sentinel_connection) getMasterAddrByNameFromSentinel(db_name string) (addr []string, returned_err error, is_client_closed bool) {
-	c.writer.WriteString("*3\r\n")
-	c.writer.WriteString("$8\r\n")
-	c.writer.WriteString("sentinel\r\n")
-	c.writer.WriteString("$23\r\n")
-	c.writer.WriteString("get-master-addr-by-name\r\n")
-	c.writer.WriteString(fmt.Sprintf("$%d\r\n", len(db_name)))
-	c.writer.WriteString(db_name)
-	c.writer.WriteString("\r\n")
-	c.writer.Flush()
+	err := c.current_sentinel_connection.SetDeadline(time.Now().Add(c.sentinel_command_timeout))
+	if err != nil {
+		return nil, err, false
+	}
+	_, err = fmt.Fprintf(c.writer, "*3\r\n$8\r\nsentinel\r\n$23\r\nget-master-addr-by-name\r\n$%d\r\n%s\r\n", len(db_name), db_name)
+	if err != nil {
+		return nil, err, false
+	}
+	err = c.writer.Flush()
+	if err != nil {
+		return nil, err, false
+	}
+	err = c.current_sentinel_connection.SetDeadline(time.Time{})
+	if err != nil {
+		return nil, err, false
+	}
 
 	return c.parseResponse()
 }
@@ -90,7 +99,7 @@ func (c *Sentinel_connection) retrieveAddressByDbName() {
 	for db_name := range c.get_master_address_by_name {
 		addr, err, is_client_closed := c.getMasterAddrByNameFromSentinel(db_name)
 		if err != nil {
-			fmt.Println("err: ", err.Error())
+			fmt.Println("failed to get master addresses: ", err.Error())
 			if !is_client_closed {
 				c.get_master_address_by_name_reply <- &Get_master_addr_reply{
 					reply: "",
@@ -128,7 +137,7 @@ func (c *Sentinel_connection) reconnectToSentinel() bool {
 			return false
 		}
 
-		c.current_sentinel_connection, err = net.DialTimeout("tcp", u.Host, 300*time.Millisecond)
+		c.current_sentinel_connection, err = net.DialTimeout("tcp", u.Host, c.sentinel_dial_timeout)
 		if err == nil {
 			c.reader = bufio.NewReader(c.current_sentinel_connection)
 			c.writer = bufio.NewWriter(c.current_sentinel_connection)
@@ -137,14 +146,14 @@ func (c *Sentinel_connection) reconnectToSentinel() bool {
 			if ok {
 				err = c.auth(pass)
 				if err != nil {
-					fmt.Println(err.Error())
+					fmt.Printf("failed to auth: %v\n", err)
 					return false
 				}
 			}
 
 			return true
 		}
-		fmt.Println(err.Error())
+		fmt.Printf("failed to dial sentinel %s: %v\n", u.Host, err)
 	}
 	return false
 }
@@ -153,15 +162,24 @@ func (c *Sentinel_connection) auth(pass string) error {
 	if pass == "" {
 		return errors.New("password is not supplied")
 	}
-	c.writer.WriteString("*2\r\n")
-	c.writer.WriteString("$4\r\n")
-	c.writer.WriteString("auth\r\n")
-	c.writer.WriteString(fmt.Sprintf("$%d\r\n", len(pass)))
-	c.writer.WriteString(fmt.Sprintf("%s\r\n", pass))
-	c.writer.WriteString("\r\n")
-	c.writer.Flush()
+	err := c.current_sentinel_connection.SetDeadline(time.Now().Add(c.sentinel_command_timeout))
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(c.writer, "*2\r\n$4\r\nauth\r\n$%d\r\n%s\r\n", len(pass), pass)
+	if err != nil {
+		return err
+	}
+	err = c.writer.Flush()
+	if err != nil {
+		return err
+	}
+	err = c.current_sentinel_connection.SetDeadline(time.Time{})
+	if err != nil {
+		return err
+	}
 
-	err := c.parseAuthResponse()
+	err = c.parseAuthResponse()
 
 	return err
 }
@@ -169,7 +187,7 @@ func (c *Sentinel_connection) auth(pass string) error {
 func (c *Sentinel_connection) parseAuthResponse() error {
 	buf, _, err := c.reader.ReadLine()
 	if err != nil {
-		return errors.New("failed read line from client")
+		return fmt.Errorf("failed read line from client: %v", err)
 	}
 
 	if !bytes.Equal([]byte("+OK"), buf) {
@@ -185,7 +203,7 @@ func (c *Sentinel_connection) GetAddressByDbName(name string) (string, error) {
 	return reply.reply, reply.err
 }
 
-func NewSentinelConnection(addresses []string) (*Sentinel_connection, error) {
+func NewSentinelConnection(addresses []string, dialTimeout, commandTimeout time.Duration) (*Sentinel_connection, error) {
 	connection := Sentinel_connection{
 		sentinels_addresses:              addresses,
 		get_master_address_by_name:       make(chan string),
@@ -193,6 +211,8 @@ func NewSentinelConnection(addresses []string) (*Sentinel_connection, error) {
 		current_sentinel_connection:      nil,
 		reader:                           nil,
 		writer:                           nil,
+		sentinel_dial_timeout:            time.Millisecond * dialTimeout,
+		sentinel_command_timeout:         time.Millisecond * commandTimeout,
 	}
 
 	if !connection.reconnectToSentinel() {


### PR DESCRIPTION
Adding AUTH support for Sentinel 5.0.

To connect with password, could be done like this:

`:mypassword@localhost:6379`